### PR TITLE
aa

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ slackEvents.on('link_shared', (event) => {
 });
 ```
 
-The event contains an array of links, which are each run through the function
+The event contains an array of links, which are each run through the functiond
 `messageAttachmentFromLink()` to fetch data about the link from Flickr, and transform the link into
 a message attachment. Message attachments have
 [rich formatting capabilities](https://api.slack.com/docs/message-attachments), and this app uses


### PR DESCRIPTION
[App Unfurls](https://api.slack.com/docs/message-link-unfurling) are a feature of the Slack Platform
that allow your Slack app customize the presentation of links that belong to a certain domain or
set of domains.a
![sm2](https://user-images.githubusercontent.com/66588796/98239764-7abdac80-1f8e-11eb-93a6-2c49696b9c42.jpg)
Sample Issue Body